### PR TITLE
pub sub example

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,18 +19,16 @@ resource "google_cloud_scheduler_job" "job" {
   }
 }
 
-resource "google_dataflow_job" "pub_sub_dataflow_job" {
-  name = "test-terraform-dataflow-job"
-  project = var.project_id
-  zone = var.zone
-
-  template_gcs_path = var.template_gcs_path
-  temp_gcs_location = var.temp_gcs_location
-
+resource "google_dataflow_flex_template_job" "pub_sub_dataflow_job" {
+  provider                = google-beta
+  project                 = var.project_id
+  name                    = "dataflow-flextemplates-job"
+  region                  = var.region
+  container_spec_gcs_path = var.template_gcs_path
   parameters = {
     inputTopic = google_pubsub_topic.topic.id
   }
 
-  on_delete = "cancel"
+  on_delete               = "drain"
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,36 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}
+
+resource "google_pubsub_topic" "topic" {
+  name = "job-topic"
+}
+
+resource "google_cloud_scheduler_job" "job" {
+  name        = "test-job"
+  description = "test job"
+  schedule    = "* * * * *"
+
+  pubsub_target {
+    topic_name = google_pubsub_topic.topic.id
+    data       = base64encode("test")
+  }
+}
+
+resource "google_dataflow_job" "pub_sub_dataflow_job" {
+  name = "test-terraform-dataflow-job"
+  project = var.project_id
+  zone = var.zone
+
+  template_gcs_path = var.template_gcs_path
+  temp_gcs_location = var.temp_gcs_location
+
+  parameters = {
+    inputTopic = google_pubsub_topic.topic.id
+  }
+
+  on_delete = "cancel"
+}
+

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,26 @@
+variable "project_id" {
+  type = string
+  default = "sandbox-307310"
+}
+
+variable "region" {
+  type = string
+  default = "europe-west3"
+}
+
+variable "zone" {
+  type = string
+  default = "europe-west3-a"
+}
+
+variable "template_gcs_path" {
+  type = string
+  description = "The GCS path to the Dataflow job template. Expect 'gs://<bucket>/<path>'. Ex: 'gs://my-bucket/templates/template_file'"
+  default = "gs://pub_sub_example/templates/pub_sub_template"
+}
+
+variable "temp_gcs_location" {
+  type = string
+  description = "A writeable location on GCS for the Dataflow job to dump its temporary data. Expect 'gs://<bucket>/<path>'. Ex: 'gs://my-bucket/tmp_dir'"
+  default     = "gs://pub_sub_example/tmp_dir"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,11 +16,5 @@ variable "zone" {
 variable "template_gcs_path" {
   type = string
   description = "The GCS path to the Dataflow job template. Expect 'gs://<bucket>/<path>'. Ex: 'gs://my-bucket/templates/template_file'"
-  default = "gs://pub_sub_example/templates/pub_sub_template"
-}
-
-variable "temp_gcs_location" {
-  type = string
-  description = "A writeable location on GCS for the Dataflow job to dump its temporary data. Expect 'gs://<bucket>/<path>'. Ex: 'gs://my-bucket/tmp_dir'"
-  default     = "gs://pub_sub_example/tmp_dir"
+  default = "gs://pub_sub_example/samples/dataflow/templates/word-count-streaming-beam.json"
 }

--- a/word-count-beam/spec/metadata.json
+++ b/word-count-beam/spec/metadata.json
@@ -6,10 +6,7 @@
     {
       "name": "inputTopic",
       "label": "Pub/Sub input subscription.",
-      "helpText": "Pub/Sub subscription to read from of the form 'projects/<PROJECT>/topics/<TOPIC>'.",
-      "regexes": [
-        "[a-zA-Z][-_.~+%a-zA-Z0-9]{2,}"
-      ]
+      "helpText": "Pub/Sub subscription to read from of the form 'projects/<PROJECT>/topics/<TOPIC>'."
     }
   ]
 }

--- a/word-count-beam/spec/metadata.json
+++ b/word-count-beam/spec/metadata.json
@@ -1,0 +1,15 @@
+
+{
+  "name": "Word Count Streaming Beam",
+  "description": "An Apache Beam streaming pipeline that reads JSON encoded messages from Pub/Sub, uses Beam SQL to transform the message data, and writes the results to a BigQuery",
+  "parameters": [
+    {
+      "name": "inputTopic",
+      "label": "Pub/Sub input subscription.",
+      "helpText": "Pub/Sub subscription to read from of the form 'projects/<PROJECT>/topics/<TOPIC>'.",
+      "regexes": [
+        "[a-zA-Z][-_.~+%a-zA-Z0-9]{2,}"
+      ]
+    }
+  ]
+}

--- a/word-count-beam/src/main/java/org/apache/beam/examples/StreamingWordCount.java
+++ b/word-count-beam/src/main/java/org/apache/beam/examples/StreamingWordCount.java
@@ -6,7 +6,6 @@ import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.StreamingOptions;
-import org.apache.beam.sdk.options.Validation;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
@@ -17,19 +16,13 @@ import org.joda.time.Duration;
 public class StreamingWordCount {
     static final int WINDOW_SIZE = 5; // Default window duration in minutes
     static final int NUM_SHARDS = 1;// Default number of shards to produce per window
-    static final String BUCKET_PATH = "gs://pub_sub_example/output";
+    static final String BUCKET_PATH = "gs://pub_sub_example/output/test";
 
     public interface Options extends StreamingOptions {
         @Description("Input PubSub topic of the form 'projects/<PROJECT>/topics/<TOPIC>'")
         ValueProvider<String> getInputTopic();
 
         void setInputTopic(ValueProvider<String> topic);
-
-        /*@Description("Path of the dir to write to")
-        @Validation.Required
-        ValueProvider<String> getOutput();
-
-        void setOutput(ValueProvider<String> value);*/
     }
 
     static void runStreamingWordCount(Options options) {

--- a/word-count-beam/src/main/java/org/apache/beam/examples/StreamingWordCount.java
+++ b/word-count-beam/src/main/java/org/apache/beam/examples/StreamingWordCount.java
@@ -2,7 +2,6 @@ package org.apache.beam.examples;
 
 import org.apache.beam.examples.common.WriteOneFilePerWindow;
 import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -13,8 +12,6 @@ import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.joda.time.Duration;
-
-import java.io.IOException;
 
 
 public class StreamingWordCount {
@@ -35,7 +32,7 @@ public class StreamingWordCount {
         void setOutput(ValueProvider<String> value);*/
     }
 
-    static void runStreamingWordCount(Options options) throws IOException {
+    static void runStreamingWordCount(Options options) {
         options.setStreaming(true);
 
         Pipeline pipeline = Pipeline.create(options);
@@ -47,15 +44,10 @@ public class StreamingWordCount {
                 .apply(MapElements.via(new WordCount.FormatAsTextFn()))
                 .apply("Write Files to GCS", new WriteOneFilePerWindow(BUCKET_PATH, NUM_SHARDS));
 
-        PipelineResult result = pipeline.run();
-        try {
-            result.waitUntilFinish();
-        } catch (Exception exc) {
-            result.cancel();
-        }
+        pipeline.run();
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) {
         Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
 
         runStreamingWordCount(options);

--- a/word-count-beam/src/main/java/org/apache/beam/examples/StreamingWordCount.java
+++ b/word-count-beam/src/main/java/org/apache/beam/examples/StreamingWordCount.java
@@ -6,7 +6,6 @@ import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.StreamingOptions;
-import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
@@ -20,9 +19,9 @@ public class StreamingWordCount {
 
     public interface Options extends StreamingOptions {
         @Description("Input PubSub topic of the form 'projects/<PROJECT>/topics/<TOPIC>'")
-        ValueProvider<String> getInputTopic();
+        String getInputTopic();
 
-        void setInputTopic(ValueProvider<String> topic);
+        void setInputTopic(String topic);
     }
 
     static void runStreamingWordCount(Options options) {

--- a/word-count-beam/src/main/java/org/apache/beam/examples/StreamingWordCount.java
+++ b/word-count-beam/src/main/java/org/apache/beam/examples/StreamingWordCount.java
@@ -1,0 +1,60 @@
+package org.apache.beam.examples;
+
+import org.apache.beam.examples.common.ExampleBigQueryTableOptions;
+import org.apache.beam.examples.common.ExampleOptions;
+import org.apache.beam.examples.common.WriteOneFilePerWindow;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.StreamingOptions;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.joda.time.Duration;
+
+
+public class StreamingWordCount {
+    static final int WINDOW_SIZE = 10; // Default window duration in minutes
+    static final int NUM_SHARDS = 1;// Default number of shards to produce per window
+
+    public interface Options
+            extends WordCount.WordCountOptions, ExampleOptions, ExampleBigQueryTableOptions, StreamingOptions {
+        @Description("Fixed window duration, in minutes")
+        @Default.Integer(WINDOW_SIZE)
+        Integer getWindowSize();
+
+        void setWindowSize(Integer value);
+
+        @Description("Fixed number of shards to produce per window")
+        @Default.Integer(NUM_SHARDS)
+        Integer getNumShards();
+
+        void setNumShards(Integer numShards);
+
+        @Description("Input PubSub topic of the form 'projects/<PROJECT>/topics/<TOPIC>'")
+        String getInputTopic();
+
+        void setInputTopic(String topic);
+    }
+
+    static void runStreamingWordCount(Options options) {
+        options.setStreaming(true);
+
+        Pipeline pipeline = Pipeline.create(options);
+
+        pipeline
+                .apply("Read PubSub messages", PubsubIO.readStrings().fromTopic(options.getInputTopic()))
+                .apply(Window.into(FixedWindows.of(Duration.standardMinutes(options.getWindowSize()))))
+                .apply(new WordCount.CountWords())
+                .apply(MapElements.via(new WordCount.FormatAsTextFn()))
+                .apply("Write Files to GCS", new WriteOneFilePerWindow(options.getOutput(), options.getNumShards()));
+    }
+
+    public static void main(String[] args) {
+        Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
+
+        runStreamingWordCount(options);
+    }
+}


### PR DESCRIPTION
`StreamingWordCount` reads from PubSub topic, counts words, writes result for each 5-minute interval to a new file in `gs://pub_sub_example/output/` bucket.

`main.tf` describes the following resources:
* PubSub topic "job-topic"
* Cloud Scheduler job "test-job" which writes message "test" to topic "job-topic" every minute
* Dataflow job "test-terraform-dataflow-job" with StreamingWordCount main class which reads from "job-topic"

To create and run Dataflow job using [google_dataflow_job](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dataflow_job) Dataflow template has been created. [(Dataflow templates)](https://cloud.google.com/dataflow/docs/concepts/dataflow-templates)
<details>
  <summary>Command to create template</summary>
  
  ```
BUCKET_NAME=pub_sub_example 
PROJECT_ID=$(gcloud config get-value project)
REGION=europe-west3-a
```
```
mvn compile exec:java -P dataflow runner \
 -Dexec.mainClass=org.apache.beam.examples.StreamingWordCount \
 -Dexec.args=" \
     --project=$PROJECT_ID \
     --region=$REGION \
     --runner=DataflowRunner \
     --stagingLocation=gs://$BUCKET_NAME/staging \
     --templateLocation=gs://$BUCKET_NAME/templates/pub_sub_template" 
```
</details>

### How to execute Terraform scripts
First run:
1. Install [terraform](https://www.terraform.io/intro/getting-started/install.html?_ga=2.265964559.1089087856.1620753664-1981765415.1620209532) and gloud.
2. cd to dir with terraform scripts
3. authenticate with GCP 
`
gcloud auth application-default login
`
4.  run `terraform init`

`terraform plan` - create execution plan. changes will not be applied.
`terraform apply` - execute plan (create resources in Google Cloud)
`terraform destroy` - tear down resources (remove PubSub topic, Scheduler job, cancel Dataflow job)

[Terraform - Getting Started with the Google Provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/getting_started)